### PR TITLE
And missing classes to `provides`

### DIFF
--- a/META.info
+++ b/META.info
@@ -8,7 +8,9 @@
   "depends" : [ ],
   "provides" : {
     "Git::Wrapper" : "lib/Git/Wrapper.pm",
-    "Git::Wrapper::Log" : "lib/Git/Log/Parser.pm"
+    "Git::Wrapper::Log" : "lib/Git/Log/Parser.pm",
+    "Git::Log::Parser" : "lib/Git/Log/Parser.pm",
+    "Git::Log::Actions": "lib/Git/Log/Parser.pm"
   },
   "support" : {
     "source" : "git://github.com/perlpilot/p6-Git-Wrapper.git"


### PR DESCRIPTION
Otherwise installation fails with 
===SORRY!===
Could not find Git::Log::Parser at line 2 in: